### PR TITLE
661 move CA file to the root home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM mitmproxy/mitmproxy:3.0.3
+EXPOSE 8081
 COPY ./ /code
-COPY ./mitmproxy-ca.pem /home/mitmproxy/.mitmproxy/mitmproxy-ca.pem
-EXPOSE 8081 8081
-WORKDIR /code
+COPY ./mitmproxy-ca.pem /root/.mitmproxy/mitmproxy-ca.pem
 RUN apk add --update py3-pip python3-dev gcc musl-dev
+WORKDIR /code
 RUN pip3 install ".[all]"
 CMD mitmweb -s /code/entrypoint.py --web-iface 0.0.0.0


### PR DESCRIPTION
This mounts the certificates in /root/.mitmproxy as opposed to
/home/mitmproxy/.mitmproxy as mitmproxy is run by root.

Tried running it as user mitmproxy, however ~/.mitmproxy is then still
owned by root due to the fact that it is defined as VOLUME in parent
Dockerfile. This makes un unable to bypass this problem, without
mounting the volume through compose/kubernetes which will cause more
issues in the future.

In conclusion, this solution, while not great, is the best we can do
at the moment.

**Tested and works with inspirehep/python-base-test.**

***PS:*** *I was wrong about the EXPOSE, you only put it once.*