### PR TITLE
http: make body bytes; add whitelist services

### DIFF
--- a/inspire_mitmproxy/services/whitelist_service.py
+++ b/inspire_mitmproxy/services/whitelist_service.py
@@ -29,8 +29,10 @@ from ..services import BaseService
 
 class WhitelistService(BaseService):
     SERVICE_HOSTS = [
-        'indexer',
         'test-indexer',
+        'test-scrapyd',
+        'test-web-e2e.local',
+        'fake-legacy',
     ]
 
     def process_request(self, request: MITMRequest):

--- a/tests/integration/test_base_service.py
+++ b/tests/integration/test_base_service.py
@@ -98,10 +98,10 @@ def test_base_service_process_request_scenario1(dispatcher, request):
     assert response_set_config.status_code == 201
 
     response_service_1 = dispatcher.process_request(request_service_1)
-    assert response_service_1.body == 'test_scenario1/TestServiceA/0'
+    assert response_service_1.body == b'test_scenario1/TestServiceA/0'
 
     response_service_2 = dispatcher.process_request(request_service_2)
-    assert response_service_2.body == 'test_scenario1/TestServiceB/0'
+    assert response_service_2.body == b'test_scenario1/TestServiceB/0'
 
 
 def test_base_service_process_request_scenario2_and_raise(dispatcher, request):
@@ -137,7 +137,7 @@ def test_base_service_process_request_scenario2_and_raise(dispatcher, request):
     assert response_set_config.status_code == 201
 
     response_service_1 = dispatcher.process_request(request_service_1)
-    assert response_service_1.body == 'test_scenario2/TestServiceA/0'
+    assert response_service_1.body == b'test_scenario2/TestServiceA/0'
 
     with raises(ScenarioNotFound):
         dispatcher.process_request(request_service_2)

--- a/tests/integration/test_whitelist_service.py
+++ b/tests/integration/test_whitelist_service.py
@@ -42,10 +42,10 @@ def test_whitelist_service_raises(dispatcher):
         dispatcher.process_request(
             MITMRequest(
                 method='GET',
-                url='http://indexer:9200/records-hep/fake',
+                url='http://test-indexer:9200/records-hep/fake',
                 body="{}",
                 headers=MITMHeaders({
-                    'Host': ['indexer:9200'],
+                    'Host': ['test-indexer:9200'],
                     'Accept': ['application/json'],
                 })
             )

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -57,9 +57,9 @@ def dispatcher():
 @mark.parametrize(
     'url, message',
     [
-        ('http://test-service-a.local', 'TestServiceA'),
-        ('http://test-service-b.local/some_path', 'TestServiceB'),
-        ('http://test-service-a.local/other_path', 'TestServiceA'),
+        ('http://test-service-a.local', b'TestServiceA'),
+        ('http://test-service-b.local/some_path', b'TestServiceB'),
+        ('http://test-service-a.local/other_path', b'TestServiceA'),
     ],
     ids=[
         'first',

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -38,6 +38,19 @@ TEST_REQUEST = MITMRequest(
 )
 
 
+TEST_REQUEST_WITH_BYTES_BODY = MITMRequest(
+    body=b'{"message": "Witaj, \xc5\x9bwiecie!"}',
+    headers=MITMHeaders({
+        'Content-Type': ['application/json; charset=UTF-8'],
+        'Accept-Encoding': ['gzip, deflate'],
+        'Connection': ['keep-alive'],
+        'User-Agent': ['python-requests/2.18.4'],
+    }),
+    method='GET',
+    url='http://127.0.0.1/test'
+)
+
+
 TEST_DICT_REQUEST = {
     'body': '{"message": "Witaj, świecie!"}',
     'headers': {
@@ -95,3 +108,7 @@ def test_request_to_dict():
     expected = TEST_DICT_REQUEST
 
     assert result == expected
+
+
+def test_request_with_bytes_body():
+    assert TEST_REQUEST == TEST_REQUEST_WITH_BYTES_BODY

--- a/tests/unit/test_http_response.py
+++ b/tests/unit/test_http_response.py
@@ -80,6 +80,19 @@ TEST_RESPONSE = MITMResponse(
     http_version='HTTP/1.1',
 )
 
+TEST_RESPONSE_WITH_BYTES_BODY = MITMResponse(
+    status_code=200,
+    status_message='OK',
+    body=b"Witaj, \xb6wiecie!",
+    headers=MITMHeaders({
+        'Content-Type': ['text/plain; charset=ISO-8859-2'],
+        'Date': ['Wed, 21 Mar 2018 12:47:18 GMT'],
+        'Server': ['nginx/1.12.2'],
+    }),
+    original_encoding='ISO-8859-2',
+    http_version='HTTP/1.1',
+)
+
 
 def test_response_from_mitmproxy():
     result = MITMResponse.from_mitmproxy(TEST_MITM_RESPONSE)
@@ -109,8 +122,12 @@ def test_response_to_dict():
     assert result == expected
 
 
-def test_responses_from_bytes_and_str_equal():
+def test_dict_responses_from_bytes_and_str_equal():
     result_from_string = MITMResponse.from_dict(TEST_DICT_RESPONSE)
     result_from_bytes = MITMResponse.from_dict(TEST_DICT_RESPONSE_WITH_BYTES_BODY)
 
     assert result_from_string == result_from_bytes
+
+
+def test_responses_from_bytes_and_str_equal():
+    assert TEST_RESPONSE == TEST_RESPONSE_WITH_BYTES_BODY


### PR DESCRIPTION
- assumption that HTTP content is printable was wrong: requests and responses now store body as bytes + encoding
- add e2e services to the proxy whitelist for arXiv E2E harvest test to work