### PR TITLE
interaction_count: be per-scenario

### DIFF
--- a/inspire_mitmproxy/services/base_service.py
+++ b/inspire_mitmproxy/services/base_service.py
@@ -24,7 +24,7 @@
 
 from os import environ
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from urllib.parse import splitport  # type: ignore
 from urllib.parse import urlparse
 
@@ -38,8 +38,8 @@ class BaseService:
     SERVICE_HOSTS: List[str] = []
 
     def __init__(self):
-        self.active_scenario: Optional[str] = None
-        self.interactions_replayed: Dict[str, Dict[str, Any]] = {}
+        self.active_scenario: str = 'default'
+        self.interactions_replayed: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
     @property
     def name(self):
@@ -67,9 +67,15 @@ class BaseService:
 
     def increment_interaction_count(self, interaction_name: str):
         try:
-            self.interactions_replayed[interaction_name]['num_calls'] += 1
+            self.interactions_replayed[self.active_scenario][interaction_name]['num_calls'] += 1
         except KeyError:
-            self.interactions_replayed.setdefault(interaction_name, {'num_calls': 1})
+            self.interactions_replayed.setdefault(
+                self.active_scenario,
+                {},
+            ).setdefault(
+                interaction_name,
+                {'num_calls': 1},
+            )
 
     def get_interactions_for_active_scenario(self) -> List[Interaction]:
         """Get a list of scenarios"""

--- a/inspire_mitmproxy/services/management_service.py
+++ b/inspire_mitmproxy/services/management_service.py
@@ -49,6 +49,10 @@ class ManagementService(BaseService):
         }
         self.config_propagate()
 
+    @property
+    def active_scenario(self):
+        return self.config.get('active_scenario', 'default')
+
     def process_request(self, request: MITMRequest) -> MITMResponse:
         parsed_url = urlparse(request.url)
         path = parsed_url.path
@@ -135,7 +139,7 @@ class ManagementService(BaseService):
     def get_service_interactions(self, service_name) -> dict:
         for service in self.services:
             if service.name == service_name:
-                return service.interactions_replayed
+                return service.interactions_replayed.get(self.active_scenario, {})
 
         raise ServiceNotFound(service_name)
 

--- a/tests/unit/test_base_service.py
+++ b/tests/unit/test_base_service.py
@@ -209,17 +209,48 @@ def test_increment_interaction_count_first(service: BaseService):
     expected = 1
 
     service.increment_interaction_count('test_interaction')
-    result = service.interactions_replayed['test_interaction']['num_calls']
+    result = service.interactions_replayed[service.active_scenario]['test_interaction']['num_calls']
 
     assert expected == result
 
 
 def test_increment_interaction_count_repeated(service: BaseService):
-    service.interactions_replayed['test_interaction'] = {'num_calls': 5}
+    service.interactions_replayed[service.active_scenario] = {
+        'test_interaction': {'num_calls': 5},
+    }
 
     expected = 6
 
     service.increment_interaction_count('test_interaction')
-    result = service.interactions_replayed['test_interaction']['num_calls']
+    result = service.interactions_replayed[service.active_scenario]['test_interaction']['num_calls']
 
     assert expected == result
+
+
+def test_increment_interaction_count_repeated_on_multiple_scenarios(service: BaseService):
+    service.interactions_replayed['scenario1'] = {
+        'test_interaction': {'num_calls': 1},
+    }
+    service.interactions_replayed['scenario2'] = {
+        'test_interaction': {'num_calls': 10},
+    }
+
+    expected_scenario1 = 2
+    expected_scenario2 = 10
+    service.active_scenario = 'scenario1'
+    service.increment_interaction_count('test_interaction')
+    result_scenario1 = service.interactions_replayed['scenario1']['test_interaction']['num_calls']
+    result_scenario2 = service.interactions_replayed['scenario2']['test_interaction']['num_calls']
+
+    assert expected_scenario1 == result_scenario1
+    assert expected_scenario2 == result_scenario2
+
+    expected_scenario1 = 2
+    expected_scenario2 = 11
+    service.active_scenario = 'scenario2'
+    service.increment_interaction_count('test_interaction')
+    result_scenario1 = service.interactions_replayed['scenario1']['test_interaction']['num_calls']
+    result_scenario2 = service.interactions_replayed['scenario2']['test_interaction']['num_calls']
+
+    assert expected_scenario1 == result_scenario1
+    assert expected_scenario2 == result_scenario2


### PR DESCRIPTION
This allows repeating the interaction names on a per-scenario basis.

Signed-off-by: David Caro <david@dcaro.es>