### PR TITLE
base_service: reset counts on scenario switch

### DIFF
--- a/inspire_mitmproxy/services/base_service.py
+++ b/inspire_mitmproxy/services/base_service.py
@@ -46,6 +46,10 @@ class BaseService:
     def name(self):
         return type(self).__name__
 
+    def set_active_scenario(self, active_scenario: str):
+        self.active_scenario = active_scenario
+        self.interactions_replayed[self.active_scenario] = {}
+
     def handles_request(self, request: MITMRequest) -> bool:
         """Can this service handle the request?"""
         try:

--- a/inspire_mitmproxy/services/management_service.py
+++ b/inspire_mitmproxy/services/management_service.py
@@ -163,5 +163,5 @@ class ManagementService(BaseService):
     def propagate_option_changes(self):
         """On change of config, propagate relevant information to services."""
         for service in self.services:
-            service.active_scenario = self.get_active_scenario()
+            service.set_active_scenario(self.get_active_scenario())
             service.is_recording = self.is_recording

--- a/tests/unit/test_base_service.py
+++ b/tests/unit/test_base_service.py
@@ -34,7 +34,7 @@ from inspire_mitmproxy.http import MITMHeaders, MITMRequest, MITMResponse
 from inspire_mitmproxy.services import BaseService
 
 
-@fixture
+@fixture(scope='function')
 def service():
     class TestService(BaseService):
         SERVICE_HOSTS = ['host_a.local', 'host_b.local']
@@ -374,3 +374,32 @@ def test_get_interactions_for_active_scenario_raises(service: BaseService, scena
 
     with raises(ScenarioNotInService):
         service.get_interactions_for_active_scenario()
+
+
+def test_set_scenario_resets_interaction_count(service: BaseService):
+    initial_interactions = {
+        'scenario_entered': {
+            'interaction_0': {
+                'num_calls': 3,
+            },
+            'interaction_1': {
+                'num_calls': 1,
+            }
+        },
+        'scenario_irrelevant': {
+            'interaction': 42,
+        },
+    }
+
+    expected = {
+        'scenario_entered': {},
+        'scenario_irrelevant': {
+            'interaction': 42,
+        },
+    }
+
+    service.interactions_replayed = initial_interactions
+    service.set_active_scenario('scenario_entered')
+    result = service.interactions_replayed
+
+    assert expected == result


### PR DESCRIPTION
This will reset interaction counts when switching to a scenario. Now, when a new test session starts with the same proxy, counts will be correct for the session, and not totalled.