### PR TITLE
882 mitm-manager: dynamic creation or services

### DIFF
--- a/inspire_mitmproxy/errors.py
+++ b/inspire_mitmproxy/errors.py
@@ -75,3 +75,17 @@ class ScenarioNotInService(MITMProxyHTTPError):
         self.http_status_code = 501
         message = f"Scenario {scenario} not found in service {service_name}"
         super().__init__(message)
+
+
+class InvalidServiceType(MITMProxyHTTPError):
+    def __init__(self, service_type: str) -> None:
+        self.http_status_code = 400
+        message = f"Service type {service_type} is not a valid service type"
+        super().__init__(message)
+
+
+class InvalidServiceParams(MITMProxyHTTPError):
+    def __init__(self, service_type: str, params: dict) -> None:
+        self.http_status_code = 400
+        message = f"Service of type {service_type} cannot be instantiated with params: {params!r}"
+        super().__init__(message)

--- a/inspire_mitmproxy/service_list.py
+++ b/inspire_mitmproxy/service_list.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE-MITMPROXY.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Priority-ordered list of services for the proxy."""
+
+from typing import Any, Dict, List
+
+from .errors import InvalidServiceParams, InvalidServiceType
+from .services.base_service import BaseService
+from .services.whitelist_service import WhitelistService
+
+
+SERVICE_TYPENAME_TO_CLASS_MAP = {
+    'BaseService': BaseService,
+    'WhitelistService': WhitelistService,
+}
+
+
+class ServiceList:
+    def __init__(self, service_list: List[BaseService]) -> None:
+        self._service_list = service_list
+
+    def replace_from_descrition(self, service_list: List[Dict[str, Any]]):
+        self._service_list = [
+            self._instantiate_service_from_dict(description)
+            for description in service_list
+        ]
+
+    def prepend(self, *args: BaseService):
+        self._service_list = list(args) + self._service_list
+
+    def _instantiate_service_from_dict(self, description: Dict[str, Any]) -> BaseService:
+        service_typename = description.pop('type', 'BaseService')
+
+        try:
+            service_class = SERVICE_TYPENAME_TO_CLASS_MAP[service_typename]
+        except KeyError:
+            raise InvalidServiceType(service_typename)
+
+        try:
+            return service_class(**description)
+        except TypeError:
+            raise InvalidServiceParams(service_typename, description)
+
+    def to_list(self) -> List[Dict[str, Any]]:
+        return [service.to_dict() for service in self._service_list]
+
+    def __iter__(self):
+        return iter(self._service_list)
+
+    def __repr__(self):
+        return f'ServiceList({self._service_list!r})'

--- a/inspire_mitmproxy/services/__init__.py
+++ b/inspire_mitmproxy/services/__init__.py
@@ -21,7 +21,3 @@
 # or submit itself to any jurisdiction.
 
 """INSPIRE-MITMProxy Fake Services."""
-
-from .base_service import BaseService  # noqa: F401
-from .management_service import ManagementService  # noqa: F401
-from .whitelist_service import WhitelistService  # noqa: F401

--- a/inspire_mitmproxy/services/base_service.py
+++ b/inspire_mitmproxy/services/base_service.py
@@ -129,3 +129,20 @@ class BaseService:
             raise ScenarioNotInService(self.name, self.active_scenario)
 
         return self.get_interactions_in_scenario(scenario_dir)
+
+    def __eq__(self, other) -> bool:
+        return (
+            type(self) == type(other) and
+            self.name == other.name and
+            self.hosts_list == other.hosts_list
+        )
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}(name={self.name!r}, hosts_list={self.hosts_list!r})'
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'type': type(self).__name__,
+            'name': self.name,
+            'hosts_list': self.hosts_list,
+        }

--- a/inspire_mitmproxy/services/whitelist_service.py
+++ b/inspire_mitmproxy/services/whitelist_service.py
@@ -25,7 +25,7 @@ import os
 
 from ..errors import DoNotIntercept
 from ..http import MITMRequest, MITMResponse
-from ..services import BaseService
+from ..services.base_service import BaseService
 
 
 class WhitelistService(BaseService):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -34,7 +34,7 @@ flake8 .
 
 echo "Running MyPy"
 export MYPYPATH="${VIRTUAL_ENV}/lib/python3.6/site-packages/"
-mypy --follow-imports=silent .
+mypy --follow-imports=silent --no-incremental .
 
 echo "Runnning PyTest"
 pytest --cov=inspire_mitmproxy \

--- a/tests/integration/test_base_service.py
+++ b/tests/integration/test_base_service.py
@@ -34,7 +34,7 @@ from yaml import load as yaml_load
 from inspire_mitmproxy.dispatcher import Dispatcher
 from inspire_mitmproxy.errors import DoNotIntercept, ScenarioNotInService, ServiceNotFound
 from inspire_mitmproxy.http import MITMHeaders, MITMRequest, MITMResponse
-from inspire_mitmproxy.services import BaseService
+from inspire_mitmproxy.services.base_service import BaseService
 
 
 @fixture(scope='function')

--- a/tests/integration/test_whitelist_service.py
+++ b/tests/integration/test_whitelist_service.py
@@ -27,7 +27,7 @@ import pytest
 from inspire_mitmproxy.dispatcher import Dispatcher
 from inspire_mitmproxy.errors import DoNotIntercept
 from inspire_mitmproxy.http import MITMHeaders, MITMRequest
-from inspire_mitmproxy.services import WhitelistService
+from inspire_mitmproxy.services.whitelist_service import WhitelistService
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/test_base_service.py
+++ b/tests/unit/test_base_service.py
@@ -31,7 +31,7 @@ from pytest import fixture, mark, raises
 
 from inspire_mitmproxy.errors import NoMatchingRecording, ScenarioNotInService
 from inspire_mitmproxy.http import MITMHeaders, MITMRequest, MITMResponse
-from inspire_mitmproxy.services import BaseService
+from inspire_mitmproxy.services.base_service import BaseService
 
 
 @fixture(scope='function')

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -24,13 +24,13 @@ import json
 
 from pytest import fixture, mark, raises
 
-from inspire_mitmproxy import services
 from inspire_mitmproxy.dispatcher import Dispatcher
 from inspire_mitmproxy.errors import NoServicesForRequest
 from inspire_mitmproxy.http import MITMHeaders, MITMRequest, MITMResponse
+from inspire_mitmproxy.services.base_service import BaseService
 
 
-class TestService(services.BaseService):
+class TestService(BaseService):
     def process_request(self, request: dict):
         return MITMResponse(
             body=self.name,
@@ -108,38 +108,45 @@ def test_dispatcher_default_services():
     )
 
     expected = {
-        "0": {
-            "class": "ManagementService",
-            "hosts_list": [
-                "mitm-manager.local"
-            ]
-        },
-        "1": {
-            "class": "ArxivService",
-            "hosts_list": [
-                "arxiv.org",
-                "export.arxiv.org"
-            ]
-        },
-        "2": {
-            "class": "LegacyService",
-            "hosts_list": [
-                "inspirehep.net"
-            ]
-        },
-        "3": {
-            "class": "RTService",
-            "hosts_list": [
-                "inspirevm13.cern.ch",
-                "rt.inspirehep.net"
-            ]
-        },
-        "4": {
-            "class": "WhitelistService",
-            "hosts_list": [
-                "test-indexer", "test-scrapyd", "test-web-e2e.local",
-            ]
-        }
+        'services': [
+            {
+                "type": "ManagementService",
+                "name": "ManagementService",
+                "hosts_list": [
+                    "mitm-manager.local"
+                ]
+            },
+            {
+                "type": "BaseService",
+                "name": "ArxivService",
+                "hosts_list": [
+                    "arxiv.org",
+                    "export.arxiv.org"
+                ]
+            },
+            {
+                "type": "BaseService",
+                "name": "LegacyService",
+                "hosts_list": [
+                    "inspirehep.net"
+                ]
+            },
+            {
+                "type": "BaseService",
+                "name": "RTService",
+                "hosts_list": [
+                    "inspirevm13.cern.ch",
+                    "rt.inspirehep.net"
+                ]
+            },
+            {
+                "type": "WhitelistService",
+                "name": "WhitelistService",
+                "hosts_list": [
+                    "test-indexer", "test-scrapyd", "test-web-e2e.local",
+                ]
+            }
+        ]
     }
     json_response = json.loads(result.body)
 

--- a/tests/unit/test_service_list.py
+++ b/tests/unit/test_service_list.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE-MITMPROXY.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Tests for the ServiceList."""
+
+from typing import Any, Dict
+
+from pytest import mark
+
+from inspire_mitmproxy.service_list import ServiceList
+from inspire_mitmproxy.services.base_service import BaseService
+from inspire_mitmproxy.services.whitelist_service import WhitelistService
+
+
+def test_service_list_replace_from_decription():
+    expected = [
+        BaseService(name='ReplacedService', hosts_list=['replaced_host.local']),
+        WhitelistService(name='WhitelistService', hosts_list=['whitelist_me.local']),
+    ]
+
+    service_list = ServiceList([
+        BaseService(name='OriginalService', hosts_list=['original_host.local']),
+    ])
+
+    service_list.replace_from_descrition([
+        {
+            'type': 'BaseService',
+            'name': 'ReplacedService',
+            'hosts_list': ['replaced_host.local'],
+        },
+        {
+            'type': 'WhitelistService',
+            'name': 'WhitelistService',
+            'hosts_list': ['whitelist_me.local'],
+        }
+    ])
+
+    assert list(service_list) == expected
+
+
+def test_service_list_prepend():
+    expected = [
+        BaseService(name='Service', hosts_list=['host.local']),
+        WhitelistService(name='WhitelistService', hosts_list=['whitelist_me.local']),
+    ]
+
+    service_list = ServiceList([
+        WhitelistService(name='WhitelistService', hosts_list=['whitelist_me.local']),
+    ])
+
+    service_list.prepend(BaseService(name='Service', hosts_list=['host.local']))
+
+    assert list(service_list) == expected
+
+
+@mark.parametrize(
+    'service_description, expected_service',
+    [
+        (
+            {
+                'type': 'BaseService',
+                'name': 'TestName',
+                'hosts_list': ['test_host.local', 'test_host2.local'],
+            },
+            BaseService(name='TestName', hosts_list=['test_host.local', 'test_host2.local']),
+        ),
+        (
+            {
+                'name': 'TestName',
+                'hosts_list': ['test_host.local'],
+            },
+            BaseService(name='TestName', hosts_list=['test_host.local']),
+        ),
+        (
+            {
+                'type': 'WhitelistService',
+                'name': 'TestWhitelist',
+                'hosts_list': ['test_host.local'],
+            },
+            WhitelistService(name='TestWhitelist', hosts_list=['test_host.local']),
+        ),
+    ],
+    ids=(
+        'base service with two hosts',
+        'base service with implicit BaseService type',
+        'whitelist service',
+    )
+)
+def test_service_list_instantiate_service_from_dict(
+    service_description: Dict[str, Any],
+    expected_service: BaseService,
+):
+    service_list = ServiceList([])
+
+    result_service = service_list._instantiate_service_from_dict(service_description)
+
+    assert expected_service == result_service
+
+
+def test_service_list_to_dict():
+    service_list = ServiceList([
+        BaseService(name='TestName', hosts_list=['test_host.local', 'test_host2.local']),
+        WhitelistService(name='TestWhitelist', hosts_list=['test_host.local']),
+    ])
+
+    expected_description = [
+        {
+            'type': 'BaseService',
+            'name': 'TestName',
+            'hosts_list': ['test_host.local', 'test_host2.local'],
+        },
+        {
+            'type': 'WhitelistService',
+            'name': 'TestWhitelist',
+            'hosts_list': ['test_host.local'],
+        },
+    ]
+
+    result_service = service_list.to_list()
+
+    assert expected_description == result_service

--- a/tests/unit/test_whitelist_service.py
+++ b/tests/unit/test_whitelist_service.py
@@ -26,7 +26,7 @@ import os
 
 from mock import patch
 
-from inspire_mitmproxy.services import WhitelistService
+from inspire_mitmproxy.services.whitelist_service import WhitelistService
 
 
 def test_load_services_from_os():


### PR DESCRIPTION
Allow for dynamic creation of services through REST to `mitm-manager` (also can do PUT):

```
<<<
POST /services HTTP/1.1
Host: mitm-manager.local
Content-Type: application/json

{
    "services": [
        {
            "type": "BaseService",
            "name": "SomeExternalService",
            "hosts_list": ["an_external_service.local"]
        },
        {
            "type": "WhitelistService",
            "name": "WhitelistService",
            "hosts_list": ["pass_through.local"]
        }
    ]
}


>>>
HTTP/1.1 201 Created
Content-Type: application/json

{
    "services": [
        {
            "type": "ManagementService",
            "name": "ManagementService",
            "hosts_list": ["mitm-manager.local"]
        },
        {
            "type": "BaseService",
            "name": "SomeExternalService",
            "hosts_list": ["an_external_service.local"]
        },
        {
            "type": "WhitelistService",
            "name": "WhitelistService",
            "hosts_list": ["pass_through.local"]
        }
    ]
}
```