### PR TITLE
global: sequential responses for the same request INSPIR-1232

### DIFF
--- a/inspire_mitmproxy/errors.py
+++ b/inspire_mitmproxy/errors.py
@@ -22,6 +22,8 @@
 
 """INSPIRE-MITMProxy Errors"""
 
+from typing import Optional
+
 from .http import MITMRequest
 
 
@@ -64,9 +66,12 @@ class DoNotIntercept(Exception):
 
 
 class NoMatchingRecording(MITMProxyHTTPError):
-    def __init__(self, service_name: str, request: MITMRequest) -> None:
+    def __init__(self, service_name: str, request: MITMRequest, reason: Optional[str]) \
+            -> None:
         self.http_status_code = 501
-        message = f"Service {service_name} cannot handle this request: {request}"
+        message = f"Service {service_name} cannot handle this request: {request}."
+        if reason:
+            message.join(f" Reason: {reason}")
         super().__init__(message)
 
 

--- a/inspire_mitmproxy/interaction.py
+++ b/inspire_mitmproxy/interaction.py
@@ -36,7 +36,6 @@ match one of the services defined in :attr:`inspire_mitmproxy.services`. Name of
 can be anything, and is only for informative purposes. When recorded automatically, interactions
 are named in sequence of `interaction_0.yaml`, `interaction_1.yaml`, and so on.
 """
-
 from functools import singledispatch
 from logging import getLogger
 from os.path import expandvars
@@ -89,12 +88,14 @@ class Interaction:
         response: MITMResponse,
         match: Optional[dict] = None,
         callbacks: Optional[List[dict]] = None,
+        max_replays: Optional[int] = None,
     ) -> None:
         self.name = name
         self.request = request
         self.response = response
         self.match = match or {}
         self.callbacks = callbacks or []
+        self.max_replays = max_replays or -1
 
     @classmethod
     def from_file(cls, interaction_file: Optional[Path]) -> 'Interaction':
@@ -107,6 +108,7 @@ class Interaction:
             response=MITMResponse.from_dict(interaction_dict['response']),
             match=interaction_dict.get('match'),
             callbacks=interaction_dict.get('callbacks'),
+            max_replays=interaction_dict.get('max_replays')
         )
 
     def to_dict(self) -> dict:
@@ -115,6 +117,7 @@ class Interaction:
             'response': self.response.to_dict(),
             'match': self.match,
             'callbacks': self.callbacks,
+            'max_replays': self.max_replays,
         }
 
         return serialized_interaction

--- a/tests/integration/fixtures/scenarios/test_scenario_replays_once_and_takes_next/TestServiceA/interaction_0.yaml
+++ b/tests/integration/fixtures/scenarios/test_scenario_replays_once_and_takes_next/TestServiceA/interaction_0.yaml
@@ -1,0 +1,12 @@
+request:
+  body: null
+  headers:
+    Accept: [application/json]
+  method: GET
+  url: https://host_a.local/api
+response:
+  body: !!python/unicode 'test_scenario_replays_ok/TestServiceA/0'
+  headers:
+    content-type: [application/json]
+  status: {code: 200, message: OK}
+max_replays: 1

--- a/tests/integration/fixtures/scenarios/test_scenario_replays_once_and_takes_next/TestServiceA/interaction_1.yaml
+++ b/tests/integration/fixtures/scenarios/test_scenario_replays_once_and_takes_next/TestServiceA/interaction_1.yaml
@@ -1,0 +1,12 @@
+request:
+  body: null
+  headers:
+    Accept: [application/json]
+  method: GET
+  url: https://host_a.local/api
+response:
+  body: !!python/unicode 'test_scenario_replays_ok/TestServiceA/1'
+  headers:
+    content-type: [application/json]
+  status: {code: 200, message: OK}
+max_replays: 1

--- a/tests/unit/fixtures/scenarios/test_scenario/TestService/interaction_0.yaml
+++ b/tests/unit/fixtures/scenarios/test_scenario/TestService/interaction_0.yaml
@@ -12,3 +12,4 @@ response:
   headers:
     content-type: [application/json; charset=UTF-8]
   status: {code: 200, message: OK}
+max_replays: -1

--- a/tests/unit/fixtures/scenarios/test_scenario/TestService/interaction_1.yaml
+++ b/tests/unit/fixtures/scenarios/test_scenario/TestService/interaction_1.yaml
@@ -12,3 +12,4 @@ response:
   headers:
     content-type: [application/json; charset=UTF-8]
   status: {code: 201, message: Created}
+max_replays: -1

--- a/tests/unit/test_interaction.py
+++ b/tests/unit/test_interaction.py
@@ -210,7 +210,8 @@ def test_interaction_to_dict(interaction_all_fields: Interaction):
                     'method': 'GET',
                 },
             },
-        ]
+        ],
+        'max_replays': -1
     }
 
     result = interaction_all_fields.to_dict()


### PR DESCRIPTION
This commit allows to build services that reply different responses
to the same request. This is achieved by introducing a `max_replay`
value which tells to the service how many times that interaction
can actually be played again. After this number is reached, the next
matching interaction is used to reply to the same request.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>